### PR TITLE
Changes owasp-crs version to 3.1.0

### DIFF
--- a/pillars/versions.sls
+++ b/pillars/versions.sls
@@ -2,5 +2,5 @@ versions:
   - nginx: 1.15.7
   - libmodsecurity: v3/master
   - connector: master
-  - owasp-crs: v3.0.2
+  - owasp-crs: v3.1.0
   - wrk: 4.0.2


### PR DESCRIPTION
Version 3.1.0 was released on 2018-11-27 

Further info is available here:
https://github.com/SpiderLabs/owasp-modsecurity-crs/releases/tag/v3.1.0